### PR TITLE
Feat/handle multiple db connection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/cache": "^6.0 || ^7.0 || ^8.0",
-        "illuminate/database": "^6.0 || ^7.0 || ^8.0",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0"
+        "illuminate/cache": "^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/database": "^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "~6.0",

--- a/src/Cacheable.php
+++ b/src/Cacheable.php
@@ -63,7 +63,7 @@ trait Cacheable {
         }
 
         $keyName = $this->getKeyName();
-        $keyValue = $this->{$keyName};
+        $keyValue = $this->getCurrentConnection()->getName().'_'.$this->{$keyName};
 
         $tagName = $this->getCacheTagName();
 
@@ -129,7 +129,8 @@ trait Cacheable {
         } else {
 
             $keyName = $model->getKeyName();
-            $keyValue = $model->{$keyName};
+            $keyValue = $model->getCurrentConnection()->getName().'_'.$model->{$keyName};
+
 
             Cache::tags($tagName)->forget($keyValue);
 


### PR DESCRIPTION
This PR handles using a different cacheKey that includes the name of the current model's database connection. The purpose of this is to prevent two models that use the same ID from conflicting when cached.